### PR TITLE
travis: automatically build csdiff in Fedora Copr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,13 @@ matrix:
         - name: "Ubuntu LTS 2020 (focal)"
           dist: focal
 
+        - name: "Fedora Copr build"
+          dist: focal
+          env:
+              - COPR_BUILD=yes
+
 install:
     - sudo apt-get install cmake help2man libboost-dev libboost-filesystem-dev libboost-program-options-dev libboost-python-dev libboost-regex-dev
 
 script:
-    - make distcheck
+    - if test -z "$COPR_BUILD"; then make distcheck; else ./.travis/copr-build ; fi

--- a/.travis/README
+++ b/.travis/README
@@ -1,0 +1,15 @@
+Scripts in this directory
+-------------------------
+
+copr-build
+    This script is executed from .travis.yml task.
+
+copr-build-setup
+    Use this to configure the remote copr project, it uploads the
+    'copr-custom-script' to Copr project.  Execute like:
+        $ ./copr-custom-script PR
+        $ ./copr-custom-script PUSH
+    .. depending on which webhook you want to setup.
+
+copr-custom-script
+    This script is used in Copr to build the package from remote git repository.

--- a/.travis/copr-build
+++ b/.travis/copr-build
@@ -1,0 +1,8 @@
+#! /bin/bash -x
+
+# Trigger the build in Copr (from .travis.yml)
+
+set -e
+curl -o copr-build https://raw.githubusercontent.com/praiskup/copr-ci-tooling/master/copr-travis-submit
+export COPR_PR_WEBHOOK="https://copr.fedorainfracloud.org/webhooks/custom/46962/a72fe511-c141-4f27-b7cf-de03c065e64e/csdiff/"
+exec bash copr-build

--- a/.travis/copr-build-setup
+++ b/.travis/copr-build-setup
@@ -1,0 +1,35 @@
+#! /bin/bash -x
+
+# Helper script to update CI scripting on Copr side
+
+script=$(readlink -f "$(dirname "$0")")/copr-custom-script
+
+PROJECT_PR=@codescan/csdiff-pull-requests
+PROJECT_PUSH=@codescan/csdiff
+
+project=
+case $1 in
+    PR|'') project=$PROJECT_PR ;;
+    PUSH) project=$PROJECT_PUSH ;;
+esac
+
+build_deps=(
+    cmake
+    coreutils
+    git
+)
+
+copr_cmd=(
+    copr edit-package-custom "$project" \
+        --webhook-rebuild on \
+        --script "$script" \
+        --script-chroot "fedora-latest-x86_64" \
+        --script-builddeps "${build_deps[*]}"
+)
+
+if test $1 != PUSH; then
+    copr_cmd+=( --max-builds 10 )
+fi
+
+
+"${copr_cmd[@]}" --name csdiff --script-resultdir srpm_results

--- a/.travis/copr-custom-script
+++ b/.travis/copr-custom-script
@@ -1,0 +1,34 @@
+#! /bin/bash -x
+
+set -e
+
+clone_url_parent=https://github.com/kdudka/csdiff.git
+
+workdir=$(basename "$clone_url_parent")
+workdir=${workdir%%.git}
+
+hook_payload=$(readlink -f "${HOOK_PAYLOAD-hook_payload}")
+
+mkdir -p "$COPR_RESULTDIR"
+resultdir=$(readlink -f "$COPR_RESULTDIR")
+
+# clone the helper scripts when needed, and add to PATH
+test -d copr-ci-tooling \
+    || git clone --depth 1 https://github.com/praiskup/copr-ci-tooling.git
+export PATH="$PWD/copr-ci-tooling:$PATH"
+
+# clone the tested project
+git clone \
+    --recursive \
+    --no-single-branch \
+    "$clone_url_parent"
+
+# checkout requested revision
+cd "$workdir"
+
+copr-travis-checkout "$hook_payload"
+
+./make-srpm.sh |& tee srpm-build.log
+srpm=$(grep Wrote: srpm-build.log | cut -d' ' -f2)
+cd "$resultdir"
+bsdtar -xf "$srpm"


### PR DESCRIPTION
Builds after pushes go to [1], builds for pull-request to [2].

[1] https://copr.fedorainfracloud.org/coprs/g/codescan/csdiff/
[2] https://copr.fedorainfracloud.org/coprs/g/codescan/csdiff-pull-requests/