### PR TITLE
travis: run copr build only for 'master' branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
           dist: focal
           env:
               - COPR_BUILD=yes
+          if: branch = master
 
 install:
     - sudo apt-get install cmake help2man libboost-dev libboost-filesystem-dev libboost-program-options-dev libboost-python-dev libboost-regex-dev

--- a/.travis/copr-build
+++ b/.travis/copr-build
@@ -1,4 +1,4 @@
-#! /bin/bash -x
+#! /bin/bash
 
 # Trigger the build in Copr (from .travis.yml)
 


### PR DESCRIPTION
    travis: run copr build only for the master branch
    
    This is needed to avoid building into the @codescan/csdiff copr project
    upon push to non-master branch.  Also, pull-requests against non-master
    branch would be excluded, but they should be rare.
    
    Drop the -x flag from the Travis build.  That PR webhook isn't a private
    information but still..  it is better to not make a honeypot from all
    our Travis logs.
