### PR TITLE
.travis.yml: trigger jobs for the master branch only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: cpp
 compiler: gcc
 
+if: branch = master
+
 matrix:
     include:
         - name: "Ubuntu LTS 2014 (trusty)"
@@ -19,7 +21,6 @@ matrix:
           dist: focal
           env:
               - COPR_BUILD=yes
-          if: branch = master
 
 install:
     - sudo apt-get install cmake help2man libboost-dev libboost-filesystem-dev libboost-program-options-dev libboost-python-dev libboost-regex-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ if: branch = master
 
 matrix:
     include:
+        - name: "Fedora Copr build"
+          dist: focal
+          env:
+              - COPR_BUILD=yes
+
         - name: "Ubuntu LTS 2014 (trusty)"
           dist: trusty
 
@@ -16,11 +21,6 @@ matrix:
 
         - name: "Ubuntu LTS 2020 (focal)"
           dist: focal
-
-        - name: "Fedora Copr build"
-          dist: focal
-          env:
-              - COPR_BUILD=yes
 
 install:
     - sudo apt-get install cmake help2man libboost-dev libboost-filesystem-dev libboost-program-options-dev libboost-python-dev libboost-regex-dev


### PR DESCRIPTION
Since my github account is used as upstream, I always need to create a branch before I submit a pull request.  It does not make any sense to trigger the jobs twice for the same git tree.

.travis.yml: run the copr build job as first in the matrix because it usually takes long time to complete.